### PR TITLE
Add path to Sharepoint endpoint

### DIFF
--- a/paths.dict
+++ b/paths.dict
@@ -44,3 +44,4 @@
 /unifiedmessaging/
 /webticket/
 /webticket/webticketservice.svc
+/_windows/default.aspx?ReturnUrl=/


### PR DESCRIPTION
Adding another endpoint to the wordlist.

The `ReturnURL` needs to be in the URL otherwise it redirects to an HTML login page. Reference [here](https://social.msdn.microsoft.com/Forums/sharepoint/en-US/0adc0ea7-5462-4348-9091-69eb58522d5f/windowsdefaultaspx-parameters?forum=sharepointcustomizationprevious)