### PR TITLE
Small bugfix on ntlmscan.py's hostsfile parameter.

### DIFF
--- a/ntlmscan.py
+++ b/ntlmscan.py
@@ -180,7 +180,7 @@ if __name__ == "__main__":
                 if hostname[:4] == "http":
                     testurl = hostname + "/" + urlpath
                 else:
-                    testurl = "https://" + args.host + "/" + urlpath
+                    testurl = "https://" + hostname + "/" + urlpath
                 queue.put([testurl, False, args.virtualhost])
     # Get ready to queue some requests
     for i in range(args.threads):


### PR DESCRIPTION
Fixes a small bug when the listed hosts contain neither http/https.