### PR TITLE
Update paths.dict

### DIFF
--- a/paths.dict
+++ b/paths.dict
@@ -34,6 +34,7 @@
 /powershell/
 /public/
 /reach/sip.svc
+/reports/
 /requesthandler/
 /requesthandlerext/
 /rgs/


### PR DESCRIPTION
Adding in default SSRS /reports/ endpoint which is often integrated with Windows NTLM authentication. Non-standard configurations or specifically configured instances with reports_(instance) might require manual fuzzing. 

https://learn.microsoft.com/en-us/sql/reporting-services/report-server/configure-web-portal?view=sql-server-ver16
https://learn.microsoft.com/en-us/sql/reporting-services/web-portal-ssrs-native-mode?view=sql-server-ver16